### PR TITLE
Make DBus optionnal

### DIFF
--- a/Qarma.cpp
+++ b/Qarma.cpp
@@ -25,9 +25,11 @@
 #include <QColorDialog>
 #include <QComboBox>
 #include <QDate>
+#ifdef DBUS_ENABLED
 #include <QDBusConnection>
 #include <QDBusConnectionInterface>
 #include <QDBusInterface>
+#endif
 #include <QDesktopWidget>
 #include <QDialogButtonBox>
 #include <QEvent>
@@ -797,6 +799,7 @@ char Qarma::showList(const QStringList &args)
 
 void Qarma::notify(const QString message, bool noClose)
 {
+#ifdef DBUS_ENABLED
     if (QDBusConnection::sessionBus().interface()->isServiceRegistered("org.freedesktop.Notifications")) {
         QDBusInterface notifications("org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications");
         const QString summary = (message.length() < 32) ? message : message.left(25) + "...";
@@ -828,6 +831,7 @@ void Qarma::notify(const QString message, bool noClose)
     SHOW_DIALOG
     dlg->adjustSize();
     dlg->move(QApplication::desktop()->availableGeometry().topRight() - QPoint(dlg->width() + 20, -20));
+#endif
 }
 
 char Qarma::showNotification(const QStringList &args)

--- a/qarma.pro
+++ b/qarma.pro
@@ -1,8 +1,13 @@
 HEADERS = Qarma.h
 SOURCES = Qarma.cpp
-QT      += dbus gui widgets
+QT      += gui widgets
 unix:!macx:QT += x11extras
 TARGET  = qarma
+
+!DISABLE_DBUS {
+	DEFINES += DBUS_ENABLED
+	QT += dbus
+}
 
 unix:!macx:LIBS    += -lX11
 unix:!macx:DEFINES += WS_X11


### PR DESCRIPTION
This allows to avoid the dependency on dbus by passing `CONFIG+=DISABLE_DBUS` to `qmake`.