### PR TITLE
Added GitHub Actions build for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - '*'
+    tags:
+    - 'v[0-9]*'
+  pull_request:
+    branches:
+    - '*'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  APP_NAME: qarma
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+        - { name: "GCC", cc: gcc, cxx: g++ }
+        - { name: "clang", cc: clang, cxx: clang++ }
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cxx }}
+    steps:
+    - name: Set Archive Name
+      if: ${{ matrix.config.cc == 'gcc' }}
+      run: |
+        echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+        echo "INSTALL_NAME=$APP_NAME-${GITHUB_REF##*/}-linux" >> "$GITHUB_ENV"
+    - uses: actions/checkout@v2
+    - name: Update Packages
+      run: sudo apt-get update
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install qtbase5-dev qttools5-dev libqt5x11extras5-dev
+    - name: Configure
+      working-directory: ${{ runner.workspace }}
+      run: |
+        mkdir build && cd build
+        qmake PREFIX="/usr/" "$GITHUB_WORKSPACE/qarma.pro"
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      run: make INSTALL_DIR="$INSTALL_NAME"
+    - name: Install
+      if: ${{ matrix.config.cc == 'gcc' }}
+      working-directory: ${{ runner.workspace }}/build
+      run: |
+        make INSTALL_ROOT="$INSTALL_NAME" install
+        tar czvf "$INSTALL_NAME".tar.gz "$INSTALL_NAME"
+    - name: Upload Artifacts
+      if: ${{ matrix.config.cc == 'gcc' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Linux Artifacts
+        path: ${{ runner.workspace }}/build/${{ env.INSTALL_NAME }}.tar.gz
+
+  deploy:
+    name: Deployment
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+    - linux
+    steps:
+    - name: Set Environment Variables
+      run: echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+    - uses: actions/download-artifact@v2
+      with:
+        name: Linux Artifacts
+    - name: Display File Information
+      run: ls -lR
+    # Note: not using `actions/create-release@v1`
+    #       because it cannot update an existing release
+    #       see https://github.com/actions/create-release/issues/29
+    - uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.INSTALL_REF }}
+        name: Release ${{ env.INSTALL_REF }}
+        draft: false
+        prerelease: false
+        files: |
+          ${{ env.APP_NAME }}-${{ env.INSTALL_REF }}-*


### PR DESCRIPTION
This adds 2 builds under Ubuntu on GitHub Actions, one to test the build with Clang and the other with GCC. The latter is also used to generate a package to be uploaded as artifacts for download.
It also provide an automatic release package upload when a GitHub Release is made (AFAIK tag + release, not just tag) using [semantic versioning](https://semver.org) (vMAJOR.MINOR.PATCH, should also cover the case without the 'v').

In a later time I could add a Windows and macOS version, and a Qt6 build alternative for all.