### PR TITLE
Fix progress autoclose when stdin is closed

### DIFF
--- a/Qarma.cpp
+++ b/Qarma.cpp
@@ -1058,6 +1058,8 @@ void Qarma::readStdIn()
 //         gs_stdin->deleteLater(); // hello segfault...
 //         gs_stdin = NULL;
         notifier->deleteLater();
+        if (m_type == Progress)
+            finishProgress();
         return;
     }
 


### PR DESCRIPTION
This fixes qarma remaining open in the following minimal test case:
```
echo 80 | qarma --progress --auto-close --no-cancel
```

It resolves Steam getting stuck when unpacking the sniper runtime.
(The "Unpacking Steam Linux Runtime container" dialog.)