### PR TITLE
Do not assume base 10 when converting QString to int

### DIFF
--- a/Qarma.cpp
+++ b/Qarma.cpp
@@ -619,7 +619,7 @@ void Qarma::quitOnError()
 #define NEXT_ARG QString((++i < args.count()) ? args.at(i) : QString())
 #define WARN_UNKNOWN_ARG(_KNOWN_) if (args.at(i).startsWith("--") && args.at(i) != _KNOWN_) qDebug() << "unspecific argument" << args.at(i);
 #define SHOW_DIALOG m_dialog = dlg; connect(dlg, SIGNAL(finished(int)), SLOT(dialogFinished(int))); dlg->show();
-#define READ_INT(_V_, _TYPE_, _ERROR_) bool ok; const int _V_ = NEXT_ARG.to##_TYPE_(&ok); if (!ok) return !error(_ERROR_)
+#define READ_INT(_V_, _TYPE_, _ERROR_) bool ok; const int _V_ = NEXT_ARG.to##_TYPE_(&ok, 0); if (!ok) return !error(_ERROR_)
 
 bool Qarma::readGeneral(QStringList &args) {
     QStringList remains;

--- a/Qarma.cpp
+++ b/Qarma.cpp
@@ -410,7 +410,7 @@ Qarma::Qarma(int &argc, char **argv) : QApplication(argc, argv)
 
 bool Qarma::error(const QString message)
 {
-    printf("Error: %s", qPrintable(message));
+    printf("Error: %s\n", qPrintable(message));
     QMetaObject::invokeMethod(this, "quitOnError", Qt::QueuedConnection);
     return true;
 }


### PR DESCRIPTION
Setting base = 0 tells Qt to [autodetect the base](https://doc.qt.io/qt-6/qstring.html#toInt) and convert the string appropriately instead of failing. This is required because some applications pass window ids as hex (argument to --attach).

For example:
<pre><b>user@Host</b>:<b>~</b>$ qarma --entry --attach 0x760000a
Error: --attach must be followed by a positive number<b>user@Host</b>:<b>~</b>$ 
</pre>

This PR also adds a missing newline so that the error message is printed correctly.

<pre><b>user@Host</b>:<b>~</b>$ qarma --entry --attach invalidnumber
Error: --attach must be followed by a positive number
<b>user@Host</b>:<b>~</b>$ 
</pre>